### PR TITLE
Fix header-bar being overridden

### DIFF
--- a/colors-discord.css
+++ b/colors-discord.css
@@ -25,7 +25,7 @@
     --profile-gradient-secondary-color: {background};
     --profile-body-background-color: {background};
 
-    --__header-bar-background: {background};
+    --__header-bar-background: {background} !important;
 
     --scrollbar-auto-track: {background};
     --scrollbar-thin-track: {background};


### PR DESCRIPTION
I was having the same issue as #1, this "solves" the bar. As for the hover stuff I'm actually not sure what the original was intended to be, but adding the following properties work to change them:
```css
--background-modifier-selected: somecolor;
--background-modifier-hover: somecolor;
```

They seem originally linked to:
```css
--background-modifier-selected: hsl(var(--primary-500-hsl) / 0.3);
--background-modifier-hover: hsl(var(--primary-500-hsl) / 0.6);
```